### PR TITLE
Fixed the documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Documentation
 
-Please refer to http://docs.prediction.io/templates/productranking/quickstart/
+Please refer to http://predictionio.incubator.apache.org/templates/productranking/quickstart/
 
 ## Version
 


### PR DESCRIPTION
The old documentation link is not working. I found this new link that should work.