### PR TITLE
Updated for PredictionIO 0.13.0 with package name changes and Scala 2.11.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Product Ranking Engine Template
 
+**September 2020: Archiving this repo as Apache PredictionIO is being moved to the attic.**
+
 ## Documentation
 
 Please refer to http://predictionio.incubator.apache.org/templates/productranking/quickstart/

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Please refer to http://predictionio.incubator.apache.org/templates/productrankin
 
 ## Version
 
+### v0.4.0
+- update for PredictionIO 0.13.0
+
 ### v0.3.0
 
 - update for PredictionIO 0.9.2, including:

--- a/build.sbt
+++ b/build.sbt
@@ -2,11 +2,13 @@ import AssemblyKeys._
 
 assemblySettings
 
+scalaVersion := "2.11.8"
+
 name := "template-scala-parallel-productranking"
 
-organization := "io.prediction"
+organization := "org.apache.predictionio"
 
 libraryDependencies ++= Seq(
-  "io.prediction"    %% "core"          % pioVersion.value % "provided",
-  "org.apache.spark" %% "spark-core"    % "1.3.0" % "provided",
-  "org.apache.spark" %% "spark-mllib"   % "1.3.0" % "provided")
+  "org.apache.predictionio"    %% "apache-predictionio-core"          % "0.13.0" % "provided",
+  "org.apache.spark" %% "spark-core"    % "2.1.1" % "provided",
+  "org.apache.spark" %% "spark-mllib"   % "2.1.1" % "provided")

--- a/src/main/scala/ALSAlgorithm.scala
+++ b/src/main/scala/ALSAlgorithm.scala
@@ -153,12 +153,15 @@ class ALSAlgorithm(val ap: ALSAlgorithmParams)
       } else {
         // sort the score
         val ord = Ordering.by[ItemScore, Double](_.score).reverse
-        val sorted = query.items.zip(scores).map{ case (iid, scoreOpt) =>
-          ItemScore(
-            item = iid,
-            score = scoreOpt.getOrElse[Double](0)
-          )
-        }.sorted(ord).toArray
+        val sorted = scores.map{s =>
+            val score = s.getOrElse[Double](0)
+            if (score >= 0) score else 0d // zero out negative scores
+          }.zip(query.items).map{ case (s, iid) =>
+            ItemScore(
+              item = iid,
+              score = s
+            )
+          }.sorted(ord).toArray
 
         PredictedResult(
           itemScores = sorted,

--- a/src/main/scala/ALSAlgorithm.scala
+++ b/src/main/scala/ALSAlgorithm.scala
@@ -6,6 +6,7 @@ import org.apache.predictionio.data.storage.BiMap
 
 import org.apache.spark.SparkContext
 import org.apache.spark.SparkContext._
+import org.apache.spark.mllib.evaluation.RankingMetrics
 import org.apache.spark.mllib.recommendation.ALS
 import org.apache.spark.mllib.recommendation.{Rating => MLlibRating}
 
@@ -96,6 +97,12 @@ class ALSAlgorithm(val ap: ALSAlgorithmParams)
     // seed for MLlib ALS
     val seed = ap.seed.getOrElse(System.nanoTime)
 
+    logger.info(s"Training with parameters [rank: ${ap.rank}, " +
+      s"num iterations: ${ap.numIterations}, " +
+      s"lambda: ${ap.lambda}, " +
+      s"seed: ${seed}]\n" +
+      s"Event count: ${data.viewEvents.count}")
+
     val m = ALS.trainImplicit(
       ratings = mllibRatings,
       rank = ap.rank,
@@ -104,6 +111,47 @@ class ALSAlgorithm(val ap: ALSAlgorithmParams)
       blocks = -1,
       alpha = 1.0,
       seed = seed)
+
+    // Training-time evaluation using Spark RankingMetrics - sometimes we get a stack overflow
+
+    // Map ratings to 1 or 0, 1 indicating an item that should be recommended
+    val binarizedRatings = mllibRatings.map(r => MLlibRating(r.user, r.product,
+      if (r.rating > 2.5) 1.0 else 0.0)).cache()
+
+    // Define a function to scale ratings from 0 to 1
+    def scaledRating(r: MLlibRating): MLlibRating = {
+      val scaledRating = math.max(math.min(r.rating, 1.0), 0.0)
+      MLlibRating(r.user, r.product, scaledRating)
+    }
+
+    // Get sorted top ten predictions for each user and then scale from [0, 1]
+    val userRecommended = m.recommendProductsForUsers(10).map { case (user, recs) =>
+      (user, recs.map(scaledRating))
+    }
+
+    // Assume that any item a user clicked through to (which maps to a 1) is a relevant document
+    // Compare with top ten most relevant documents
+    val userItems = binarizedRatings.groupBy(_.user)
+    val relevantDocuments = userItems.join(userRecommended).map { case (user, (actual,
+      predictions)) =>
+        (predictions.map(_.product), actual.filter(_.rating > 0.0).map(_.product).toArray)
+    }
+    relevantDocuments.cache()
+
+    // Instantiate metrics object
+    val metrics = new RankingMetrics(relevantDocuments)
+
+    val metricResults : Map[String, Double] = Map(
+      "Precision at 1" -> metrics.precisionAt(1),
+      "Precision at 5" -> metrics.precisionAt(5),
+      "Precision at 10" -> metrics.precisionAt(10),
+      "MAP" -> metrics.meanAveragePrecision,
+      "NDCG at 1" -> metrics.ndcgAt(1),
+      "NDCG at 5" -> metrics.ndcgAt(5),
+      "NDCG at 10" -> metrics.ndcgAt(10)
+    )
+
+    logger.info(s"Training metrics ${metricResults}.")
 
     new ALSModel(
       rank = m.rank,

--- a/src/main/scala/ALSAlgorithm.scala
+++ b/src/main/scala/ALSAlgorithm.scala
@@ -1,8 +1,8 @@
 package org.template.productranking
 
-import io.prediction.controller.P2LAlgorithm
-import io.prediction.controller.Params
-import io.prediction.data.storage.BiMap
+import org.apache.predictionio.controller.P2LAlgorithm
+import org.apache.predictionio.controller.Params
+import org.apache.predictionio.data.storage.BiMap
 
 import org.apache.spark.SparkContext
 import org.apache.spark.SparkContext._

--- a/src/main/scala/DataSource.scala
+++ b/src/main/scala/DataSource.scala
@@ -1,11 +1,11 @@
 package org.template.productranking
 
-import io.prediction.controller.PDataSource
-import io.prediction.controller.EmptyEvaluationInfo
-import io.prediction.controller.EmptyActualResult
-import io.prediction.controller.Params
-import io.prediction.data.storage.Event
-import io.prediction.data.store.PEventStore
+import org.apache.predictionio.controller.PDataSource
+import org.apache.predictionio.controller.EmptyEvaluationInfo
+import org.apache.predictionio.controller.EmptyActualResult
+import org.apache.predictionio.controller.Params
+import org.apache.predictionio.data.storage.Event
+import org.apache.predictionio.data.store.PEventStore
 
 import org.apache.spark.SparkContext
 import org.apache.spark.SparkContext._

--- a/src/main/scala/Engine.scala
+++ b/src/main/scala/Engine.scala
@@ -1,7 +1,7 @@
 package org.template.productranking
 
-import io.prediction.controller.IEngineFactory
-import io.prediction.controller.Engine
+import org.apache.predictionio.controller.IEngineFactory
+import org.apache.predictionio.controller.Engine
 
 case class Query(
   user: String,

--- a/src/main/scala/Preparator.scala
+++ b/src/main/scala/Preparator.scala
@@ -1,6 +1,6 @@
 package org.template.productranking
 
-import io.prediction.controller.PPreparator
+import org.apache.predictionio.controller.PPreparator
 
 import org.apache.spark.SparkContext
 import org.apache.spark.SparkContext._

--- a/src/main/scala/Serving.scala
+++ b/src/main/scala/Serving.scala
@@ -1,6 +1,6 @@
 package org.template.productranking
 
-import io.prediction.controller.LServing
+import org.apache.predictionio.controller.LServing
 
 class Serving
   extends LServing[Query, PredictedResult] {

--- a/template.json
+++ b/template.json
@@ -1,1 +1,1 @@
-{"pio": {"version": { "min": "0.9.2" }}}
+{"pio": {"version": { "min": "0.13.0" }}}


### PR DESCRIPTION
Along similar lines to 
https://github.com/PredictionIO/template-scala-parallel-productranking/pull/1 but for the current version.